### PR TITLE
Add payment account dropdowns on sales and enforce single cash account

### DIFF
--- a/electron/db/repositories/accounts.js
+++ b/electron/db/repositories/accounts.js
@@ -9,7 +9,12 @@ function getById(id) {
 }
 
 function create({ name, type, balance = 0 }) {
-  const result = getDb()
+  const db = getDb();
+  if (type === "cash") {
+    const existingCash = db.prepare("SELECT id FROM accounts WHERE type = 'cash' LIMIT 1").get();
+    if (existingCash) throw new Error("Only one cash account is allowed. Add bank accounts for additional payment destinations.");
+  }
+  const result = db
     .prepare("INSERT INTO accounts (name, type, balance) VALUES (?, ?, ?)")
     .run(name, type, balance);
   logSync("accounts", result.lastInsertRowid, "upsert");

--- a/electron/db/repositories/sales.js
+++ b/electron/db/repositories/sales.js
@@ -61,6 +61,18 @@ function createSale({ customerId, items, cashAmount = 0, bankAmount = 0, account
     const dueAmount = subtotal - paidAmount;
     if (dueAmount < 0) throw new Error("Paid amount exceeds total");
     if (dueAmount > 0 && !customerId) throw new Error("Select a customer for udhar sales");
+    if (cashAmount > 0) {
+      if (!accountId) throw new Error("Select a cash account for this payment");
+      const cashAccount = db.prepare("SELECT id, type FROM accounts WHERE id = ?").get(accountId);
+      if (!cashAccount) throw new Error("Cash account not found");
+      if (cashAccount.type !== "cash") throw new Error("Selected account is not a cash account");
+    }
+    if (bankAmount > 0) {
+      if (!bankAccountId) throw new Error("Select a bank account for this payment");
+      const bankAccount = db.prepare("SELECT id, type FROM accounts WHERE id = ?").get(bankAccountId);
+      if (!bankAccount) throw new Error("Bank account not found");
+      if (bankAccount.type !== "bank") throw new Error("Selected account is not a bank account");
+    }
 
     let paymentType = "cash";
     if (dueAmount === subtotal) paymentType = "udhar";

--- a/src/pages/Accounts.jsx
+++ b/src/pages/Accounts.jsx
@@ -77,6 +77,13 @@ export default function Accounts() {
   if (error) return <ErrorBox message={error} onRetry={reload} />;
 
   const total = accounts?.reduce((s, a) => s + a.balance, 0) || 0;
+  const hasCashAccount = accounts?.some((a) => a.type === "cash");
+
+  const openCreate = () => {
+    setForm({ name: "", type: hasCashAccount ? "bank" : "cash", balance: "" });
+    setErrors({});
+    setOpen(true);
+  };
 
   return (
     <div>
@@ -86,7 +93,7 @@ export default function Accounts() {
         actions={
           <div className="toolbar">
             <button className="btn-secondary" onClick={() => setTransferOpen(true)}>Transfer</button>
-            <button className="btn-primary" onClick={() => setOpen(true)}>Add Account</button>
+            <button className="btn-primary" onClick={openCreate}>Add Account</button>
           </div>
         }
       />
@@ -115,12 +122,15 @@ export default function Accounts() {
           <FormField label="Account Name" required error={errors.name}>
             <Input required value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="e.g. Cash Drawer, HBL" error={errors.name} maxLength={80} />
           </FormField>
-          <FormField label="Type">
+          <FormField
+            label="Type"
+            hint={hasCashAccount ? "Only one cash account is allowed. Add more bank accounts as needed." : "You can have one cash account and multiple bank accounts."}
+          >
             <SelectMenu
               value={form.type}
               onChange={(v) => setForm({ ...form, type: v })}
               options={[
-                { value: "cash", label: "Cash" },
+                ...(hasCashAccount ? [] : [{ value: "cash", label: "Cash" }]),
                 { value: "bank", label: "Bank" },
               ]}
             />

--- a/src/pages/NewSale.jsx
+++ b/src/pages/NewSale.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useAsync } from "../hooks/useAsync";
 import { api } from "../lib/api";
 import { toPaisa } from "../lib/format";
@@ -15,13 +15,33 @@ export default function NewSale({ setTab }) {
   const [customerId, setCustomerId] = useState("");
   const [cashAmount, setCashAmount] = useState("");
   const [bankAmount, setBankAmount] = useState("");
+  const [cashAccountId, setCashAccountId] = useState("");
+  const [bankAccountId, setBankAccountId] = useState("");
   const [notes, setNotes] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [fieldErrors, setFieldErrors] = useState({});
 
-  const cashAccount = accounts?.find((a) => a.type === "cash" && a.is_default) || accounts?.find((a) => a.type === "cash");
-  const bankAccount = accounts?.find((a) => a.type === "bank");
+  const cashAccounts = useMemo(() => accounts?.filter((a) => a.type === "cash") || [], [accounts]);
+  const bankAccounts = useMemo(() => accounts?.filter((a) => a.type === "bank") || [], [accounts]);
+  const cashPaisa = toPaisa(cashAmount || 0);
+  const bankPaisa = toPaisa(bankAmount || 0);
+
+  useEffect(() => {
+    if (!cashAccounts.length) return;
+    const defaultCash = cashAccounts.find((a) => a.is_default) || cashAccounts[0];
+    setCashAccountId((current) => current || String(defaultCash.id));
+  }, [cashAccounts]);
+
+  useEffect(() => {
+    if (bankPaisa <= 0) {
+      setBankAccountId("");
+      return;
+    }
+    if (bankAccounts.length === 1) {
+      setBankAccountId(String(bankAccounts[0].id));
+    }
+  }, [bankPaisa, bankAccounts]);
 
   const filtered = useMemo(() => {
     if (!products) return [];
@@ -30,8 +50,6 @@ export default function NewSale({ setTab }) {
   }, [products, search]);
 
   const subtotal = cart.reduce((s, c) => s + c.lineTotal, 0);
-  const cashPaisa = toPaisa(cashAmount || 0);
-  const bankPaisa = toPaisa(bankAmount || 0);
   const paid = cashPaisa + bankPaisa;
   const due = subtotal - paid;
 
@@ -110,14 +128,16 @@ export default function NewSale({ setTab }) {
     if (cashErr) e.cash = cashErr;
     const bankErr = validateMoney(bankAmount, { min: 0, fieldName: "Bank amount" });
     if (bankErr) e.bank = bankErr;
-    if (cashPaisa > 0 && !cashAccount) e.cash = "No cash account configured";
-    if (bankPaisa > 0 && !bankAccount) e.bank = "No bank account configured";
+    if (cashPaisa > 0 && !cashAccountId) e.cashAccount = "Select a cash account";
+    if (cashPaisa > 0 && !cashAccounts.length) e.cash = "No cash account configured";
+    if (bankPaisa > 0 && !bankAccountId) e.bankAccount = "Select a bank account";
+    if (bankPaisa > 0 && !bankAccounts.length) e.bank = "No bank account configured";
     if (due > 0 && !customerId) e.customer = "Select a customer for udhar (credit) sales";
     if (due < 0) e.payment = "Total paid cannot exceed sale amount";
     if (subtotal > 0 && paid === 0 && !customerId) e.customer = "Select a customer for full udhar sale";
     setFieldErrors(e);
     if (Object.keys(e).length) {
-      setError(e.cart || e.payment || e.customer || e.cash || e.bank || "Please fix the errors below");
+      setError(e.cart || e.payment || e.customer || e.cash || e.bank || e.cashAccount || e.bankAccount || "Please fix the errors below");
       return false;
     }
     setError("");
@@ -133,13 +153,14 @@ export default function NewSale({ setTab }) {
         items: cart.map((c) => ({ productId: c.productId, qty: c.qty, unitPrice: c.unitPrice })),
         cashAmount: cashPaisa,
         bankAmount: bankPaisa,
-        accountId: cashPaisa > 0 ? cashAccount?.id : null,
-        bankAccountId: bankPaisa > 0 ? bankAccount?.id : null,
+        accountId: cashPaisa > 0 ? Number(cashAccountId) : null,
+        bankAccountId: bankPaisa > 0 ? Number(bankAccountId) : null,
         notes,
       });
       setCart([]);
       setCashAmount("");
       setBankAmount("");
+      setBankAccountId("");
       setNotes("");
       setCustomerId("");
       setFieldErrors({});
@@ -288,11 +309,36 @@ export default function NewSale({ setTab }) {
           </div>
 
           <FormField label="Cash received" hint="Amount paid in cash" error={fieldErrors.cash}>
-            <MoneyInput value={cashAmount} onChange={(e) => { setCashAmount(e.target.value); setFieldErrors((f) => ({ ...f, cash: null })); }} placeholder="0" error={fieldErrors.cash} />
+            <MoneyInput value={cashAmount} onChange={(e) => { setCashAmount(e.target.value); setFieldErrors((f) => ({ ...f, cash: null, cashAccount: null })); }} placeholder="0" error={fieldErrors.cash} />
           </FormField>
+          {cashPaisa > 0 && (
+            <FormField label="Deposit to cash account" error={fieldErrors.cashAccount}>
+              <SelectMenu
+                value={cashAccountId}
+                onChange={(v) => { setCashAccountId(v); setFieldErrors((f) => ({ ...f, cashAccount: null })); }}
+                error={fieldErrors.cashAccount}
+                placeholder="Select cash account"
+                options={cashAccounts.map((a) => ({ value: String(a.id), label: a.name }))}
+              />
+            </FormField>
+          )}
           <FormField label="Bank received" hint="Amount paid to bank account" error={fieldErrors.bank}>
-            <MoneyInput value={bankAmount} onChange={(e) => { setBankAmount(e.target.value); setFieldErrors((f) => ({ ...f, bank: null })); }} placeholder="0" error={fieldErrors.bank} />
+            <MoneyInput value={bankAmount} onChange={(e) => { setBankAmount(e.target.value); setFieldErrors((f) => ({ ...f, bank: null, bankAccount: null })); }} placeholder="0" error={fieldErrors.bank} />
           </FormField>
+          {bankPaisa > 0 && (
+            <FormField label="Deposit to bank account" error={fieldErrors.bankAccount}>
+              <SelectMenu
+                value={bankAccountId}
+                onChange={(v) => { setBankAccountId(v); setFieldErrors((f) => ({ ...f, bankAccount: null })); }}
+                error={fieldErrors.bankAccount}
+                placeholder="Select bank account"
+                options={[
+                  ...(bankAccounts.length > 1 ? [{ value: "", label: "Select bank account" }] : []),
+                  ...bankAccounts.map((a) => ({ value: String(a.id), label: a.name })),
+                ]}
+              />
+            </FormField>
+          )}
 
           {due > 0 && (
             <div className="rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 px-4 py-3 text-amber-700 dark:text-amber-300 text-sm font-medium">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When creating a sale, users can now choose which account receives each payment. Cash and bank payments each show a dropdown once an amount is entered.

## Changes

### New Sale
- **Cash payment**: shows a "Deposit to cash account" dropdown when cash amount > 0
- **Bank payment**: shows a "Deposit to bank account" dropdown when bank amount > 0, so users can pick among multiple bank accounts
- Auto-selects the default cash account and auto-selects the bank account when only one exists
- Backend validates that selected accounts match the payment type (cash vs bank)

### Accounts
- Only **one cash account** is allowed (enforced in UI and backend)
- **Multiple bank accounts** can still be created
- Add Account form hides the Cash type option once a cash account exists, with a hint explaining the rule

## Testing

- [x] Frontend build passes (`npm run build:frontend`)
- [ ] Manual: create sale with cash payment and verify account dropdown
- [ ] Manual: create sale with bank payment and verify bank account selection with multiple banks
- [ ] Manual: verify second cash account cannot be created

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3cc8-5b19-79b2-8d92-29a69ab37403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3cc8-5b19-79b2-8d92-29a69ab37403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

